### PR TITLE
Refactor sanitizeBody

### DIFF
--- a/apps/backend/app/types/enums.ts
+++ b/apps/backend/app/types/enums.ts
@@ -21,30 +21,3 @@ export enum Status {
     LOGIN_SUCCESS = "User logged in successfully!",
     LOGOUT_SUCCESS = "User logged out successfully!"
 }
-
-export interface ServiceMember {
-    userId: number;
-    addressLineOne: string;
-    addressLineTwo?: string;
-    branch: Branch;
-    country?: string;
-    state?: string;
-    zipCode?: string;
-}
-
-export interface CreateUserRequest {
-    email: string;
-    password: string;
-    firstName: string;
-    lastName: string;
-    phoneNumber: string;
-    userType: UserType;
-    gender: Gender;
-    branch: Branch;
-    addressLineOne?: string;
-    addressLineTwo?: string;
-    city?: string;
-    country?: string;
-    state?: string;     
-    zipCode?: string;   
-}

--- a/apps/backend/app/types/interfaces.ts
+++ b/apps/backend/app/types/interfaces.ts
@@ -1,0 +1,28 @@
+
+export type UserType = "VOLUNTEER" | "SERVICE_MEMBER"; 
+export type Gender = "MALE" | "FEMALE";
+export type Branch = "ARMY" | "NAVY" | "AIR_FORCE" | "SPACE_FORCE" | "COAST_GUARD" | "NATIONAL_GUARD" | "MARINES";
+
+export interface UserFields {
+    email: string;
+    password: string;
+    firstName: string;
+    lastName: string;
+    phoneNumber: string;
+    gender: string;
+    userType: string;
+}
+
+export interface ServiceMemberFields {
+    branch?: string;
+    addressLineOne?: string;
+    addressLineTwo?: string;
+    country?: string;
+    state?: string;
+    city?: string;
+    zipCode?: string;
+}
+
+export type RegisterUserRequest = 
+    | (UserFields & { userType: "VOLUNTEER" })
+    | (UserFields & ServiceMemberFields & { userType: "SERVICE_MEMBER" });


### PR DESCRIPTION
## Problem:

Currently, `sanitizeBody` has multiple if statements to check if a field is in the response body. All the fields are also under one interface (`CreateUserInterface`), which includes fields that were not originally present. This violates the "interface segregation" principle in S.O.L.I.D, so I decided it would be better to separate the fields into two interfaces: `UserFields` and `ServiceMemberFields`. Both interfaces will be merged inside the request only if the user is a service member.

When I initially tried to refactor this function, I received a `type 'string' is not assignable to type 'never'` error.  

## Investigation:

Upon further investigation, the issue was due to the `gender`, `branch`, and `userTypes` fields. Since `sanitizeInput` takes a string and returns a clean version of it, this was causing TypeScript to throw an error because of those types. 

## Approach:

A solution was to treat every field as a string when sanitizing the fields and then infer the types after validation. I also replaced `CreateUserRequest` with `RegisterUserRequest`, which only includes the required fields depending on the `userType`.

This resolved the `type 'string' is not assignable to type 'never'` error and allows me to implement changes without breaking the rest of the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the registration process to support distinct user roles, including additional details for service members.
  
- **Refactor**
  - Streamlined input sanitization and validation during sign-up.
  - Consolidated and updated underlying user data structures for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->